### PR TITLE
Use brand slug instead of name for URL

### DIFF
--- a/100percentdesign/brands.html
+++ b/100percentdesign/brands.html
@@ -15,7 +15,7 @@ layout: default
             <h2>{{ brand.name }}</h2>
             <div class="image" style="background-image: url('{{ site.baseurl }}{{ brand.image }}');"></div>
             <p>{{ brand.description }}</p>
-            <a class="button" href="https://clippings.com/{{ brand.name }}" target="_blank">Shop {{ brand.name }}</a>
+            <a class="button" href="https://clippings.com/{{ brand.slug }}" target="_blank">Shop {{ brand.name }}</a>
         </li>
     {% endfor %}
     </ul>

--- a/_data/brands.yml
+++ b/_data/brands.yml
@@ -1,4 +1,5 @@
 - name: Arper
+  slug: arper
   description: Arper is an Italian company producing and distributing office, home and contract sector furniture worldwide.
   location: "Stand: W248"
   image: "/images/brands/arper.jpg"


### PR DESCRIPTION
The name of the brand and its slug used in the URL could differ materially.
